### PR TITLE
Fixes for TYPO3 v11

### DIFF
--- a/Classes/ViewHelpers/SlideStackViewHelper.php
+++ b/Classes/ViewHelpers/SlideStackViewHelper.php
@@ -38,8 +38,8 @@ class SlideStackViewHelper extends AbstractViewHelper
             $file = $slide->getOriginalFile();
 
             $item = [
-                'thumbnail' => '/' . $this->createProcessedThumbnail($file)->getPublicUrl(true),
-                'enlarged' => '/' . $this->createProcessedEnlarged($file)->getPublicUrl(true),
+                'thumbnail' => $this->createProcessedThumbnail($file)->getPublicUrl(true),
+                'enlarged' => $this->createProcessedEnlarged($file)->getPublicUrl(true),
                 'title' => $slide->getProperty('title'),
                 'desc' => $slide->getProperty('description'),
                 'slideLink' => $slide->getProperty('link'),

--- a/Configuration/FlexForm/NaturalCarousel.xml
+++ b/Configuration/FlexForm/NaturalCarousel.xml
@@ -13,7 +13,7 @@
                 <el>
                     <settings.images>
                         <TCEforms>
-                            <label>LLL:EXT:lang/locallang_general.xlf:LGL.images</label>
+                            <label>LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.images</label>
                             <config>
                                 <type>inline</type>
                                 <appearance type="array">


### PR DESCRIPTION
Fixes images path in SlideStackViewHelper and fixes a flexform label.